### PR TITLE
add Dockerfile and readme for front-end

### DIFF
--- a/hivemind-web-main/.dockerignore
+++ b/hivemind-web-main/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+build
+node_modules

--- a/hivemind-web-main/Dockerfile
+++ b/hivemind-web-main/Dockerfile
@@ -1,0 +1,14 @@
+from node:12-alpine
+
+WORKDIR /src
+
+COPY package.json /src/
+COPY package-lock.json /src/
+
+RUN npm install
+
+ADD . /src
+
+EXPOSE 3000
+
+CMD npm start

--- a/hivemind-web-main/README.md
+++ b/hivemind-web-main/README.md
@@ -1,1 +1,26 @@
 # hivemind-web
+
+This is the React front-end part of the project.
+
+## Local Usage
+
+[Install docker](https://docs.docker.com/get-docker/) and build the Docker image:
+```sh
+sudo docker build . -t hivemind-web
+```
+
+Then run the container with:
+```sh
+sudo docker run -it --rm \
+    -v ${PWD}:/src \
+    -v /src/node_modules \
+    -p 80:3000 \
+    -e CHOKIDAR_USEPOLLING=true \
+    hivemind-web
+```
+
+Visit: http://localhost/
+
+## Cloud Usage
+
+An `app.yaml` is included for running this with Google Cloud.


### PR DESCRIPTION
This PR adds a Dockerfile to make it easier to run the React front-end locally and make changes. This also adds a readme that says how to run the front-end using Docker.